### PR TITLE
Revert "Adding support for deep swaddling of arrays"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "Swaddle acts as a wrapper around unknown collections of key-value pairs.",
     "type": "library",
     "license": "MIT",
+    "version": "0.1.0",
     "authors": [
         {
             "name": "Liam Morriss",

--- a/src/Swaddle.php
+++ b/src/Swaddle.php
@@ -100,8 +100,6 @@ final class Swaddle
             $property = $this->underlying->{$name};
             if ($this->deep && $property instanceof \stdClass) {
                 $property = static::wrapObject($property);
-            } elseif ($this->deep && is_array($property)) {
-                $property = static::wrapArray($property);
             }
             return $property;
         }

--- a/test/SwaddleTest.php
+++ b/test/SwaddleTest.php
@@ -104,21 +104,6 @@ class SwaddleTest extends TestCase
     }
 
     /**
-     * Test that an array property is converted to a Swaddle when retrieved from a deep Swaddle.
-     *
-     * @covers liampm\Swaddle\Swaddle::getProperty()
-     */
-    public function test_retrieving_array_property_in_deep_swaddle()
-    {
-        $swaddle = Swaddle::wrapArray(['object' => []]);
-
-        $property = $swaddle->getProperty('object');
-
-        $this->assertInstanceOf(Swaddle::class, $property);
-        $this->assertEquals(Swaddle::wrapArray([]), $property);
-    }
-
-    /**
      * Test that a stdClass property remains unaltered when retrieved from a non deep Swaddle.
      *
      * @covers liampm\Swaddle\Swaddle::getProperty()
@@ -128,18 +113,6 @@ class SwaddleTest extends TestCase
         $swaddle = Swaddle::wrapArray(['settings' => (object)['on' => true]], false);
 
         $this->assertEquals((object)['on' => true], $swaddle->getProperty('settings'));
-    }
-
-    /**
-     * Test that an array property remains unaltered when retrieved from a non deep Swaddle.
-     *
-     * @covers liampm\Swaddle\Swaddle::getProperty()
-     */
-    public function test_retrieving_array_property_in_non_deep_swaddle()
-    {
-        $swaddle = Swaddle::wrapArray(['settings' => ['on' => true]], false);
-
-        $this->assertEquals(['on' => true], $swaddle->getProperty('settings'));
     }
 
     /**


### PR DESCRIPTION
This reverts commit 5d77f43320c7b27068b7ac8a2f4e391b480b1771.